### PR TITLE
Bind `operation` to `this` in `#atomic` and `#transaction`

### DIFF
--- a/db-session.js
+++ b/db-session.js
@@ -47,7 +47,7 @@ const api = module.exports = {
     return function atomic$operation () {
       return Promise.try(() => {
         const args = [].slice.call(arguments)
-        return api.session.atomic(operation, args)
+        return api.session.atomic(operation.bind(this), args)
       })
     }
   },
@@ -56,7 +56,7 @@ const api = module.exports = {
     return function transaction$operation () {
       return Promise.try(() => {
         const args = [].slice.call(arguments)
-        return api.session.transaction(operation, args)
+        return api.session.transaction(operation.bind(this), args)
       })
     }
   },

--- a/test/basic-atomic-concurrency-test.js
+++ b/test/basic-atomic-concurrency-test.js
@@ -89,7 +89,7 @@ test('test nested atomic transaction order', assert => {
   }).then(() => {
     assert.equal(LOGS.join('\n').replace(/_[\d_]+$/gm, '_TS'), `
 BEGIN
-SAVEPOINT save_0_runSubOperation_TS
+SAVEPOINT save_0_bound_runSubOperation_TS
 load 0 0
 release 0 0
 load 0 1
@@ -98,10 +98,10 @@ load 0 2
 release 0 2
 load 0 3
 release 0 3
-RELEASE SAVEPOINT save_0_runSubOperation_TS
+RELEASE SAVEPOINT save_0_bound_runSubOperation_TS
 load 1
 release 1
-SAVEPOINT save_1_runSubOperation_TS
+SAVEPOINT save_1_bound_runSubOperation_TS
 load 2 0
 release 2 0
 load 2 1
@@ -110,7 +110,7 @@ load 2 2
 release 2 2
 load 2 3
 release 2 3
-RELEASE SAVEPOINT save_1_runSubOperation_TS
+RELEASE SAVEPOINT save_1_bound_runSubOperation_TS
 load 3
 release 3
 COMMIT

--- a/test/basic-atomic-from-session-test.js
+++ b/test/basic-atomic-from-session-test.js
@@ -28,8 +28,8 @@ test('test immediate atomic', assert => {
   }).then(() => {
     assert.equal(LOGS.join('\n').replace(/_[\d_]+$/gm, '_TS'), `
 BEGIN
-SAVEPOINT save_0_runOperation_TS
-RELEASE SAVEPOINT save_0_runOperation_TS
+SAVEPOINT save_0_bound_runOperation_TS
+RELEASE SAVEPOINT save_0_bound_runOperation_TS
 COMMIT
 release
 `.trim())

--- a/test/basic-rollback-test.js
+++ b/test/basic-rollback-test.js
@@ -49,8 +49,8 @@ test('rolling back atomic calls ROLLBACK', assert => {
   .then(() => {
     assert.equal(LOGS.join('\n').replace(/_[\d_]+$/gm, '_TS'), `
 BEGIN
-SAVEPOINT save_0_anon_TS
-ROLLBACK TO SAVEPOINT save_0_anon_TS
+SAVEPOINT save_0_bound_TS
+ROLLBACK TO SAVEPOINT save_0_bound_TS
 ROLLBACK
 `.trim())
   })


### PR DESCRIPTION
Not doing this was causing `user-acl-two`'s `Package#delete` to error
out due to lack of `this`.
