### PR TITLE
Pluggable cls

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "devDependencies": {
     "pg": "^7.1.2",
     "standard": "^10.0.2",
-    "tap": "^10.3.2"
+    "tap": "^12.1.1"
   },
   "dependencies": {
     "bluebird": "^3.5.0"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/npm/pg-db-session#readme",
   "devDependencies": {
-    "pg": "^6.1.5",
+    "pg": "^7.1.2",
     "standard": "^10.0.2",
     "tap": "^10.3.2"
   },

--- a/test/basic-api-errors-test.js
+++ b/test/basic-api-errors-test.js
@@ -2,6 +2,7 @@
 
 const test = require('tap').test
 
+require('./setup')
 const domain = require('../lib/domain.js')
 const db = require('../db-session.js')
 
@@ -19,16 +20,20 @@ test('test atomic outside of session', assert => {
   const testAtomic = db.atomic(function testAtomic () {
   })
 
-  testAtomic()
+  return testAtomic()
     .then(() => { throw new Error('expected error') })
-    .catch(db.NoSessionAvailable, () => assert.end())
-    .catch(err => assert.end(err))
+    .catch(err => {
+      assert.type(err, db.NoSessionAvailable)
+    })
 })
 
 test('test getConnection after release', assert => {
   const domain1 = domain.create()
 
-  db.install(domain1, getConnection, {maxConcurrency: 0})
+  db.setup(() => process.domain)
+  domain1.run(() => {
+    db.install(getConnection, {maxConcurrency: 0})
+  })
 
   domain1.run(() => {
     return db.transaction(() => {
@@ -36,8 +41,9 @@ test('test getConnection after release', assert => {
       setImmediate(() => {
         session.getConnection()
           .then(pair => { throw new Error('should not reach here') })
-          .catch(db.NoSessionAvailable, () => assert.ok(1, 'caught err'))
-          .catch(err => assert.fail(err))
+          .catch(err => {
+            assert.type(err, db.NoSessionAvailable)
+          })
           .finally(assert.end)
       })
     })()
@@ -47,8 +53,8 @@ test('test getConnection after release', assert => {
 
   function getConnection () {
     return {
-      connection: {query (sql, ready) {
-        return ready()
+      connection: {async query (sql) {
+        return
       }},
       release () {
       }
@@ -59,7 +65,9 @@ test('test getConnection after release', assert => {
 test('test transaction after release', assert => {
   const domain1 = domain.create()
 
-  db.install(domain1, getConnection, {maxConcurrency: 0})
+  domain1.run(() => {
+    db.install(getConnection, {maxConcurrency: 0})
+  })
 
   domain1.run(() => {
     return db.transaction(() => {
@@ -67,8 +75,9 @@ test('test transaction after release', assert => {
       setImmediate(() => {
         session.transaction(() => {})
           .then(pair => { throw new Error('should not reach here') })
-          .catch(db.NoSessionAvailable, () => assert.ok(1, 'caught err'))
-          .catch(err => assert.fail(err))
+          .catch(err => {
+            assert.type(err, db.NoSessionAvailable)
+          })
           .finally(assert.end)
       })
     })()
@@ -78,9 +87,10 @@ test('test transaction after release', assert => {
 
   function getConnection () {
     return {
-      connection: {query (sql, ready) {
-        return ready()
-      }},
+      connection: {
+        async query (sql) {
+        }
+      },
       release () {
       }
     }

--- a/test/basic-atomic-error-test.js
+++ b/test/basic-atomic-error-test.js
@@ -3,6 +3,7 @@
 const Promise = require('bluebird')
 const test = require('tap').test
 
+require('./setup')
 const domain = require('../lib/domain.js')
 const db = require('../db-session.js')
 
@@ -12,12 +13,11 @@ const db = require('../db-session.js')
 test('test error in previous query', assert => {
   const domain1 = domain.create()
 
-  db.install(domain1, getConnection, {maxConcurrency: 0})
-
   domain1.run(() => {
+    db.install(getConnection, {maxConcurrency: 0})
     return db.atomic(() => {
       const first = db.getConnection().then(conn => {
-        return Promise.promisify(conn.connection.query)('ONE')
+        return conn.connection.query('ONE')
           .then(() => conn.release())
           .catch(err => conn.release(err))
       })
@@ -25,7 +25,7 @@ test('test error in previous query', assert => {
       const second = first.then(() => {
         return db.getConnection()
       }).then(conn => {
-        return Promise.promisify(conn.connection.query)('TWO')
+        return conn.connection.query('TWO')
           .then(() => conn.release())
           .catch(err => conn.release(err))
       })
@@ -40,12 +40,13 @@ test('test error in previous query', assert => {
 
   function getConnection () {
     return {
-      connection: {query (sql, ready) {
-        if (sql === 'ONE') {
-          return ready(new Error('failed'))
+      connection: {
+        async query (sql) {
+          if (sql === 'ONE') {
+            throw new Error('failed')
+          }
         }
-        return ready()
-      }},
+      },
       release () {
       }
     }
@@ -57,31 +58,32 @@ test('test error in BEGIN', assert => {
   const domain1 = domain.create()
   class BeginError extends Error {}
 
-  db.install(domain1, getConnection, {maxConcurrency: 0})
-
   domain1.run(() => {
+    db.install(getConnection, {maxConcurrency: 0})
     return db.atomic(() => {
       assert.fail('should not reach here.')
     })()
   })
-  .catch(BeginError, () => assert.ok(1, 'caught expected err'))
-  .catch(err => assert.fail(err))
+  .catch(err => {
+    assert.type(err, BeginError)
+  })
   .finally(() => domain1.exit())
   .finally(assert.end)
 
   function getConnection () {
     var trippedBegin = false
     return {
-      connection: {query (sql, ready) {
-        if (trippedBegin) {
-          assert.fail('should not run subsequent queries')
+      connection: {
+        query (sql) {
+          if (trippedBegin) {
+            assert.fail('should not run subsequent queries')
+          }
+          if (sql === 'BEGIN') {
+            trippedBegin = true
+            throw new BeginError('failed BEGIN')
+          }
         }
-        if (sql === 'BEGIN') {
-          trippedBegin = true
-          return ready(new BeginError('failed BEGIN'))
-        }
-        return ready()
-      }},
+      },
       release () {
       }
     }
@@ -93,26 +95,27 @@ test('test error in COMMIT', assert => {
   const domain1 = domain.create()
   class CommitError extends Error {}
 
-  db.install(domain1, getConnection, {maxConcurrency: 0})
-
   domain1.run(() => {
+    db.install(getConnection, {maxConcurrency: 0})
     return db.atomic(() => {
       return db.getConnection().then(pair => pair.release())
     })()
   })
-  .catch(CommitError, () => assert.ok(1, 'caught expected error'))
-  .catch(err => assert.fail(err))
+  .catch(err => {
+    assert.type(err, CommitError)
+  })
   .finally(() => domain1.exit())
   .finally(assert.end)
 
   function getConnection () {
     return {
-      connection: {query (sql, ready) {
-        if (sql === 'COMMIT') {
-          return ready(new CommitError('failed COMMIT'))
+      connection: {
+        async query (sql) {
+          if (sql === 'COMMIT') {
+            throw new CommitError('failed COMMIT')
+          }
         }
-        return ready()
-      }},
+      },
       release () {
       }
     }
@@ -123,17 +126,20 @@ test('test error in ROLLBACK: does not reuse connection', assert => {
   const domain1 = domain.create()
   class RollbackError extends Error {}
 
-  db.install(domain1, getConnection, {maxConcurrency: 1})
 
   var connectionPair = null
   domain1.run(() => {
+    db.install(getConnection, {maxConcurrency: 1})
     const first = db.atomic(() => {
       return db.getConnection().then(pair => {
         connectionPair = pair.pair
         pair.release()
         throw new Error('any kind of error, really')
       })
-    })().reflect()
+    })().then(
+      xs => [null, xs],
+      xs => [xs, null]
+    )
 
     const second = db.getConnection().then(pair => {
       // with concurrency=1, we will try to re-use
@@ -151,12 +157,13 @@ test('test error in ROLLBACK: does not reuse connection', assert => {
 
   function getConnection () {
     return {
-      connection: {query (sql, ready) {
-        if (sql === 'ROLLBACK') {
-          return ready(new RollbackError('failed ROLLBACK'))
+      connection: {
+        async query (sql) {
+          if (sql === 'ROLLBACK') {
+            throw new RollbackError('failed ROLLBACK')
+          }
         }
-        return ready()
-      }},
+      },
       release () {
       }
     }

--- a/test/basic-atomic-from-session-test.js
+++ b/test/basic-atomic-from-session-test.js
@@ -2,6 +2,7 @@
 
 const test = require('tap').test
 
+require('./setup')
 const domain = require('../lib/domain.js')
 const db = require('../db-session.js')
 

--- a/test/basic-interleaved-test.js
+++ b/test/basic-interleaved-test.js
@@ -3,6 +3,7 @@
 const test = require('tap').test
 const fs = require('fs')
 
+require('./setup')
 const domain = require('../lib/domain.js')
 const db = require('../db-session.js')
 
@@ -11,8 +12,8 @@ test('test of interleaved requests', assert => {
   const domain1 = domain.create()
   const domain2 = domain.create()
 
-  db.install(domain1, getFakeConnection)
-  db.install(domain2, getFakeConnection)
+  domain1.run(() => db.install(domain1, getFakeConnection))
+  domain2.run(() => db.install(domain2, getFakeConnection))
 
   var pending = 3
 

--- a/test/basic-session-concurrency-test.js
+++ b/test/basic-session-concurrency-test.js
@@ -3,6 +3,7 @@
 const Promise = require('bluebird')
 const test = require('tap').test
 
+require('./setup')
 const domain = require('../lib/domain.js')
 const db = require('../db-session.js')
 
@@ -11,8 +12,8 @@ const LOGS = []
 test('test root session concurrency=0', assert => {
   const start = process.domain
   const domain1 = domain.create()
-  db.install(domain1, innerGetConnection, {maxConcurrency: 0})
   domain1.run(() => {
+    db.install(innerGetConnection, {maxConcurrency: 0})
     return runOperations()
   }).then(() => {
     domain1.exit()
@@ -51,8 +52,8 @@ release
 test('test root session concurrency=1', assert => {
   const start = process.domain
   const domain1 = domain.create()
-  db.install(domain1, innerGetConnection, {maxConcurrency: 1})
   domain1.run(() => {
+    db.install(innerGetConnection, {maxConcurrency: 1})
     return runOperations()
   }).then(() => {
     domain1.exit()
@@ -84,8 +85,8 @@ release
 test('test root session concurrency=2', assert => {
   const start = process.domain
   const domain1 = domain.create()
-  db.install(domain1, innerGetConnection, {maxConcurrency: 2})
   domain1.run(() => {
+    db.install(innerGetConnection, {maxConcurrency: 2})
     return runOperations()
   }).then(() => {
     domain1.exit()
@@ -118,8 +119,8 @@ release
 test('test root session concurrency=4', assert => {
   const start = process.domain
   const domain1 = domain.create()
-  db.install(domain1, innerGetConnection, {maxConcurrency: 4})
   domain1.run(() => {
+    db.install(innerGetConnection, {maxConcurrency: 4})
     return runOperations()
   }).then(() => {
     domain1.exit()
@@ -153,8 +154,10 @@ release
 
 function innerGetConnection () {
   return {
-    connection: {query () {
-    }},
+    connection: {
+      async query () {
+      }
+    },
     release () {
       LOGS.push(`release`)
     }

--- a/test/basic-session-error-test.js
+++ b/test/basic-session-error-test.js
@@ -3,6 +3,7 @@
 const Promise = require('bluebird')
 const test = require('tap').test
 
+require('./setup')
 const domain = require('../lib/domain.js')
 const db = require('../db-session.js')
 
@@ -15,11 +16,12 @@ test('cannot connect', assert => {
   const domain1 = domain.create()
   class TestError extends Error {}
 
-  db.install(domain1, () => new Promise((resolve, reject) => {
-    reject(new TestError('cannot connect'))
-  }), {maxConcurrency: 0})
 
   domain1.run(() => {
+    db.install(() => new Promise((resolve, reject) => {
+      reject(new TestError('cannot connect'))
+    }), {maxConcurrency: 0})
+
     return db.getConnection().then(pair => {
       pair.release()
     })
@@ -36,10 +38,10 @@ test('query error', assert => {
   LOGS.length = 0
   const domain1 = domain.create()
 
-  db.install(domain1, innerGetConnection, {maxConcurrency: 0})
   shouldErrorToggle = new Error('the kraken')
 
   domain1.run(() => {
+    db.install(innerGetConnection, {maxConcurrency: 0})
     return db.getConnection().then(pair => {
       return new Promise((resolve, reject) => {
         pair.connection.query('FAKE QUERY', err => {
@@ -62,12 +64,12 @@ test('query error: pending connections', assert => {
   const domain1 = domain.create()
   class TestError extends Error {}
 
-  db.install(domain1, innerGetConnection, {maxConcurrency: 1})
   shouldErrorToggle = new TestError('the beast')
 
   var firstConnection = null
   var secondConnection = null
   domain1.run(() => {
+    db.install(innerGetConnection, {maxConcurrency: 1})
     return Promise.join(db.getConnection().then(pair => {
       firstConnection = pair
       return new Promise((resolve, reject) => {
@@ -75,7 +77,7 @@ test('query error: pending connections', assert => {
           err ? reject(err) : resolve()
         })
       }).then(pair.release, pair.release)
-    }).reflect(), db.getConnection().then(pair => {
+    }).then(xs => {}, xs => {}), db.getConnection().then(pair => {
       assert.ok(firstConnection)
       assert.notEqual(firstConnection, pair)
       secondConnection = pair
@@ -84,7 +86,7 @@ test('query error: pending connections', assert => {
           err ? reject(err) : resolve()
         })
       }).then(pair.release, pair.release)
-    }).reflect(), db.getConnection().then(pair => {
+    }).then(xs => {}, xs => {}), db.getConnection().then(pair => {
       assert.ok(secondConnection)
       assert.equal(secondConnection, pair)
       return new Promise((resolve, reject) => {
@@ -92,7 +94,7 @@ test('query error: pending connections', assert => {
           err ? reject(err) : resolve()
         })
       }).then(pair.release, pair.release)
-    }).reflect())
+    }).then(xs => {}, xs => {}))
   })
   .catch(err => assert.fail(err))
   .finally(() => domain1.exit())

--- a/test/basic-transaction-concurrency-test.js
+++ b/test/basic-transaction-concurrency-test.js
@@ -3,6 +3,7 @@
 const Promise = require('bluebird')
 const test = require('tap').test
 
+require('./setup')
 const domain = require('../lib/domain.js')
 const db = require('../db-session.js')
 

--- a/test/basic-transaction-error-test.js
+++ b/test/basic-transaction-error-test.js
@@ -3,6 +3,7 @@
 const Promise = require('bluebird')
 const test = require('tap').test
 
+require('./setup')
 const domain = require('../lib/domain.js')
 const db = require('../db-session.js')
 
@@ -12,12 +13,11 @@ const db = require('../db-session.js')
 test('test error in previous query', assert => {
   const domain1 = domain.create()
 
-  db.install(domain1, getConnection, {maxConcurrency: 0})
-
   domain1.run(() => {
+    db.install(getConnection, {maxConcurrency: 0})
     return db.transaction(() => {
       const first = db.getConnection().then(conn => {
-        return Promise.promisify(conn.connection.query)('ONE')
+        return conn.connection.query('ONE')
           .then(() => conn.release())
           .catch(err => conn.release(err))
       })
@@ -25,7 +25,7 @@ test('test error in previous query', assert => {
       const second = first.then(() => {
         return db.getConnection()
       }).then(conn => {
-        return Promise.promisify(conn.connection.query)('TWO')
+        return conn.connection.query('TWO')
           .then(() => conn.release())
           .catch(err => conn.release(err))
       })
@@ -40,12 +40,13 @@ test('test error in previous query', assert => {
 
   function getConnection () {
     return {
-      connection: {query (sql, ready) {
-        if (sql === 'ONE') {
-          return ready(new Error('failed'))
+      connection: {
+        async query (sql, ready) {
+          if (sql === 'ONE') {
+            throw new Error('failed')
+          }
         }
-        return ready()
-      }},
+      },
       release () {
       }
     }
@@ -57,31 +58,31 @@ test('test error in BEGIN', assert => {
   const domain1 = domain.create()
   class BeginError extends Error {}
 
-  db.install(domain1, getConnection, {maxConcurrency: 0})
 
   domain1.run(() => {
+    db.install(getConnection, {maxConcurrency: 0})
     return db.transaction(() => {
       assert.fail('should not reach here.')
     })()
   })
-  .catch(BeginError, () => assert.ok(1, 'caught expected err'))
-  .catch(err => assert.fail(err))
+  .catch(err => assert.type(err, BeginError))
   .finally(() => domain1.exit())
   .finally(assert.end)
 
   function getConnection () {
     var trippedBegin = false
     return {
-      connection: {query (sql, ready) {
-        if (trippedBegin) {
-          assert.fail('should not run subsequent queries')
+      connection: {
+        async query (sql, ready) {
+          if (trippedBegin) {
+            assert.fail('should not run subsequent queries')
+          }
+          if (sql === 'BEGIN') {
+            trippedBegin = true
+            throw new BeginError('failed BEGIN')
+          }
         }
-        if (sql === 'BEGIN') {
-          trippedBegin = true
-          return ready(new BeginError('failed BEGIN'))
-        }
-        return ready()
-      }},
+      },
       release () {
       }
     }
@@ -93,26 +94,25 @@ test('test error in COMMIT', assert => {
   const domain1 = domain.create()
   class CommitError extends Error {}
 
-  db.install(domain1, getConnection, {maxConcurrency: 0})
-
   domain1.run(() => {
+    db.install(getConnection, {maxConcurrency: 0})
     return db.transaction(() => {
       return db.getConnection().then(pair => pair.release())
     })()
   })
-  .catch(CommitError, () => assert.ok(1, 'caught expected error'))
-  .catch(err => assert.fail(err))
+  .catch(err => assert.type(err, CommitError))
   .finally(() => domain1.exit())
   .finally(assert.end)
 
   function getConnection () {
     return {
-      connection: {query (sql, ready) {
-        if (sql === 'COMMIT') {
-          return ready(new CommitError('failed COMMIT'))
+      connection: {
+        async query (sql, ready) {
+          if (sql === 'COMMIT') {
+            throw new CommitError('failed COMMIT')
+          }
         }
-        return ready()
-      }},
+      },
       release () {
       }
     }
@@ -123,17 +123,17 @@ test('test error in ROLLBACK: does not reuse connection', assert => {
   const domain1 = domain.create()
   class RollbackError extends Error {}
 
-  db.install(domain1, getConnection, {maxConcurrency: 1})
 
   var connectionPair = null
   domain1.run(() => {
+    db.install(getConnection, {maxConcurrency: 1})
     const first = db.transaction(() => {
       return db.getConnection().then(pair => {
         connectionPair = pair.pair
         pair.release()
         throw new Error('any kind of error, really')
       })
-    })().reflect()
+    })().then(xs => {}, xs => {})
 
     const second = db.getConnection().then(pair => {
       // with concurrency=1, we will try to re-use
@@ -151,12 +151,13 @@ test('test error in ROLLBACK: does not reuse connection', assert => {
 
   function getConnection () {
     return {
-      connection: {query (sql, ready) {
-        if (sql === 'ROLLBACK') {
-          return ready(new RollbackError('failed ROLLBACK'))
+      connection: {
+        async query (sql) {
+          if (sql === 'ROLLBACK') {
+            throw new RollbackError('failed ROLLBACK')
+          }
         }
-        return ready()
-      }},
+      },
       release () {
       }
     }

--- a/test/integrate-pg-pool-sequence-test.js
+++ b/test/integrate-pg-pool-sequence-test.js
@@ -27,6 +27,7 @@ test('setup', assert => setup().then(assert.end))
 test('pg pooling does not adversely affect operation', assert => {
   const domain1 = domain.create()
   const domain2 = domain.create()
+  const pool = new pg.Pool(`postgres://localhost/${TEST_DB_NAME}`)
 
   db.install(domain1, getConnection, {maxConcurrency: 0})
   db.install(domain2, getConnection, {maxConcurrency: 0})
@@ -46,12 +47,12 @@ test('pg pooling does not adversely affect operation', assert => {
 
   return runTwo
     .catch(assert.fail)
-    .finally(() => pg.end())
+    .finally(() => pool.end())
     .finally(assert.end)
 
   function getConnection () {
     return new Promise((resolve, reject) => {
-      pg.connect(`postgres://localhost/${TEST_DB_NAME}`, onconn)
+      pool.connect(onconn)
 
       function onconn (err, connection, release) {
         err ? reject(err) : resolve({connection, release})

--- a/test/integrate-pg-pool-sequence-test.js
+++ b/test/integrate-pg-pool-sequence-test.js
@@ -5,6 +5,7 @@ const Promise = require('bluebird')
 const test = require('tap').test
 const pg = require('pg')
 
+require('./setup')
 const domain = require('../lib/domain.js')
 const db = require('../db-session.js')
 
@@ -29,20 +30,23 @@ test('pg pooling does not adversely affect operation', assert => {
   const domain2 = domain.create()
   const pool = new pg.Pool(`postgres://localhost/${TEST_DB_NAME}`)
 
-  db.install(domain1, getConnection, {maxConcurrency: 0})
-  db.install(domain2, getConnection, {maxConcurrency: 0})
-
-  const runOne = domain1.run(() => runOperation(domain1))
-    .then(() => {
-      domain1.exit()
-      assert.ok(!process.domain)
-    })
+  const d = process.domain
+  const runOne = domain1.run(() => {
+    db.install(getConnection, {maxConcurrency: 0})
+    return runOperation(domain1)
+  }).then(() => {
+    domain1.exit()
+    assert.equal(process.domain, d)
+  })
 
   const runTwo = runOne.then(() => {
-    return domain2.run(() => runOperation(domain2))
+    return domain2.run(() => {
+      db.install(getConnection, {maxConcurrency: 0})
+      return runOperation(domain2)
+    })
   }).then(() => {
     domain2.exit()
-    assert.ok(!process.domain)
+    assert.equal(process.domain, d)
   })
 
   return runTwo
@@ -64,7 +68,7 @@ test('pg pooling does not adversely affect operation', assert => {
     assert.equal(process.domain, expectDomain)
     const getConnPair = db.getConnection()
 
-    const runSQL = getConnPair.get('connection').then(conn => {
+    const runSQL = getConnPair.then(xs => xs.connection).then(conn => {
       assert.equal(process.domain, expectDomain)
       return new Promise((resolve, reject) => {
         assert.equal(process.domain, expectDomain)
@@ -75,11 +79,11 @@ test('pg pooling does not adversely affect operation', assert => {
       })
     })
 
-    const runRelease = runSQL.return(getConnPair).then(
+    const runRelease = runSQL.then(() => getConnPair).then(
       pair => pair.release()
     )
 
-    return runRelease.return(runSQL)
+    return runRelease.then(() => runSQL)
   }
 })
 

--- a/test/integrate-pummel-leak-test.js
+++ b/test/integrate-pummel-leak-test.js
@@ -69,7 +69,7 @@ function runChild () {
   const ITERATIONS = 70000
   var count = 0
   var pending = 20
-
+  const pool = new pg.Pool(`postgres://localhost/${TEST_DB_NAME}`)
   var done = null
   const doRun = new Promise((resolve, reject) => {
     done = resolve
@@ -90,7 +90,7 @@ function runChild () {
   }
 
   return doRun
-    .finally(() => pg.end())
+    .finally(() => pool.end())
 
   function run () {
     const domain1 = domain.create()
@@ -122,7 +122,7 @@ function runChild () {
 
   function getConnection () {
     return new Promise((resolve, reject) => {
-      pg.connect(`postgres://localhost/${TEST_DB_NAME}`, onconn)
+      pool.connect(onconn)
 
       function onconn (err, connection, release) {
         err ? reject(err) : resolve({connection, release})

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,0 +1,15 @@
+/* eslint-disable node/no-deprecated-api */
+const db = require('../db-session.js')
+const domain = require('domain')
+
+db.setup(() => process.domain)
+
+domain.Domain.prototype.end = domain.Domain.prototype.exit
+domain.Domain.prototype.nest = function () {
+  const subdomain = domain.create()
+  subdomain.enter()
+  return subdomain
+}
+
+domain.Domain.prototype.claim = function () {
+}


### PR DESCRIPTION
This adds a new `db.setup()` function that takes a function that the system will call to get the current CLS context, and removes the `domain` parameter from `install()`. It _also_ removes bluebird completely, and refactors core parts of the API to use `async/await`. This is the first step in moving off of domains.