### PR TITLE
Replace non Bluebird catch styles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 coverage/
+node_modules
+package-lock.json

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@npm/pg-db-session",
-  "version": "1.4.2",
+  "version": "1.4.0",
   "description": "domain-attached database sessions",
   "main": "db-session.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@npm/pg-db-session",
-  "version": "1.3.2",
+  "version": "1.4.2",
   "description": "domain-attached database sessions",
   "main": "db-session.js",
   "scripts": {

--- a/test/basic-api-errors-test.js
+++ b/test/basic-api-errors-test.js
@@ -14,9 +14,8 @@ test('test transaction outside of session', assert => {
     .catch(err => {
       if(err instanceof db.NoSessionAvailable) {
           assert.end()
-      } else {
-          assert.end(err)
       }
+      assert.end(err)
     })
 })
 
@@ -29,9 +28,8 @@ test('test atomic outside of session', assert => {
     .catch(err => {
       if(err instanceof db.NoSessionAvailable) {
           assert.end()
-      } else {
-          assert.end(err)
       }
+      assert.end(err)
     })
 })
 
@@ -49,9 +47,8 @@ test('test getConnection after release', assert => {
           .catch(err => {
             if(err instanceof db.NoSessionAvailable) {
                 assert.ok(1, 'caught err')
-            } else {
-                assert.fail(err)
             }
+            assert.fail(err)
           })
           .finally(assert.end)
       })
@@ -85,9 +82,8 @@ test('test transaction after release', assert => {
           .catch(err => {
             if(err instanceof db.NoSessionAvailable) {
                 assert.ok(1, 'caught err')
-            } else {
-                assert.fail(err)
             }
+            assert.fail(err)
           })
           .finally(assert.end)
       })

--- a/test/basic-api-errors-test.js
+++ b/test/basic-api-errors-test.js
@@ -11,8 +11,13 @@ test('test transaction outside of session', assert => {
 
   testTransaction()
     .then(() => { throw new Error('expected error') })
-    .catch(db.NoSessionAvailable, () => assert.end())
-    .catch(err => assert.end(err))
+    .catch(err => {
+      if(err instanceof db.NoSessionAvailable) {
+          assert.end()
+      } else {
+          assert.end(err)
+      }
+    })
 })
 
 test('test atomic outside of session', assert => {
@@ -21,8 +26,13 @@ test('test atomic outside of session', assert => {
 
   testAtomic()
     .then(() => { throw new Error('expected error') })
-    .catch(db.NoSessionAvailable, () => assert.end())
-    .catch(err => assert.end(err))
+    .catch(err => {
+      if(err instanceof db.NoSessionAvailable) {
+          assert.end()
+      } else {
+          assert.end(err)
+      }
+    })
 })
 
 test('test getConnection after release', assert => {
@@ -36,8 +46,13 @@ test('test getConnection after release', assert => {
       setImmediate(() => {
         session.getConnection()
           .then(pair => { throw new Error('should not reach here') })
-          .catch(db.NoSessionAvailable, () => assert.ok(1, 'caught err'))
-          .catch(err => assert.fail(err))
+          .catch(err => {
+            if(err instanceof db.NoSessionAvailable) {
+                assert.ok(1, 'caught err')
+            } else {
+                assert.fail(err)
+            }
+          })
           .finally(assert.end)
       })
     })()
@@ -67,8 +82,13 @@ test('test transaction after release', assert => {
       setImmediate(() => {
         session.transaction(() => {})
           .then(pair => { throw new Error('should not reach here') })
-          .catch(db.NoSessionAvailable, () => assert.ok(1, 'caught err'))
-          .catch(err => assert.fail(err))
+          .catch(err => {
+            if(err instanceof db.NoSessionAvailable) {
+                assert.ok(1, 'caught err')
+            } else {
+                assert.fail(err)
+            }
+          })
           .finally(assert.end)
       })
     })()

--- a/test/basic-atomic-error-test.js
+++ b/test/basic-atomic-error-test.js
@@ -67,9 +67,8 @@ test('test error in BEGIN', assert => {
   .catch(err => {
     if(err instanceof BeginError) {
         assert.ok(1, 'caught expected err')
-    } else {
-        assert.fail(err)
     }
+    assert.fail(err)
   })
   .finally(() => domain1.exit())
   .finally(assert.end)
@@ -108,9 +107,8 @@ test('test error in COMMIT', assert => {
   .catch(err => {
     if(err instanceof CommitError) {
         assert.ok(1, 'caught expected error')
-    } else {
-        assert.fail(err)
-    }
+    } 
+    assert.fail(err)
   })
   .finally(() => domain1.exit())
   .finally(assert.end)

--- a/test/basic-atomic-error-test.js
+++ b/test/basic-atomic-error-test.js
@@ -64,8 +64,13 @@ test('test error in BEGIN', assert => {
       assert.fail('should not reach here.')
     })()
   })
-  .catch(BeginError, () => assert.ok(1, 'caught expected err'))
-  .catch(err => assert.fail(err))
+  .catch(err => {
+    if(err instanceof BeginError) {
+        assert.ok(1, 'caught expected err')
+    } else {
+        assert.fail(err)
+    }
+  })
   .finally(() => domain1.exit())
   .finally(assert.end)
 
@@ -100,8 +105,13 @@ test('test error in COMMIT', assert => {
       return db.getConnection().then(pair => pair.release())
     })()
   })
-  .catch(CommitError, () => assert.ok(1, 'caught expected error'))
-  .catch(err => assert.fail(err))
+  .catch(err => {
+    if(err instanceof CommitError) {
+        assert.ok(1, 'caught expected error')
+    } else {
+        assert.fail(err)
+    }
+  })
   .finally(() => domain1.exit())
   .finally(assert.end)
 

--- a/test/basic-session-error-test.js
+++ b/test/basic-session-error-test.js
@@ -25,11 +25,17 @@ test('cannot connect', assert => {
     })
   }).then(() => {
     throw new Error('expected an exception')
-  }).catch(TestError, () => assert.ok(1, 'saw exception')).then(() => {
-    domain1.exit()
+  }).catch(err => {
+    if(err instanceof TestError) {
+        assert.ok(1, 'saw exception')
+    } else {
+        throw err
+    }
+  }).then(() => {
+      domain1.exit()
   }).then(() => assert.end())
-    .catch(assert.end)
-})
+      .catch(assert.end)
+  })
 
 // what happens when there's an error querying?
 test('query error', assert => {

--- a/test/basic-transaction-error-test.js
+++ b/test/basic-transaction-error-test.js
@@ -64,8 +64,13 @@ test('test error in BEGIN', assert => {
       assert.fail('should not reach here.')
     })()
   })
-  .catch(BeginError, () => assert.ok(1, 'caught expected err'))
-  .catch(err => assert.fail(err))
+  .catch(err => {
+    if(err instanceof BeginError) {
+        assert.ok(1, 'caught expected err')
+    } else {
+        assert.fail(err)
+    }
+  })
   .finally(() => domain1.exit())
   .finally(assert.end)
 
@@ -100,8 +105,13 @@ test('test error in COMMIT', assert => {
       return db.getConnection().then(pair => pair.release())
     })()
   })
-  .catch(CommitError, () => assert.ok(1, 'caught expected error'))
-  .catch(err => assert.fail(err))
+  .catch(err => {
+    if(err instanceof CommitError) {
+        assert.ok(1, 'caught expected error')
+    } else {
+        assert.fail(err)
+    }
+  })
   .finally(() => domain1.exit())
   .finally(assert.end)
 

--- a/test/basic-transaction-error-test.js
+++ b/test/basic-transaction-error-test.js
@@ -67,9 +67,8 @@ test('test error in BEGIN', assert => {
   .catch(err => {
     if(err instanceof BeginError) {
         assert.ok(1, 'caught expected err')
-    } else {
-        assert.fail(err)
     }
+    assert.fail(err)
   })
   .finally(() => domain1.exit())
   .finally(assert.end)
@@ -108,9 +107,8 @@ test('test error in COMMIT', assert => {
   .catch(err => {
     if(err instanceof CommitError) {
         assert.ok(1, 'caught expected error')
-    } else {
-        assert.fail(err)
     }
+    assert.fail(err)
   })
   .finally(() => domain1.exit())
   .finally(assert.end)


### PR DESCRIPTION
This pull request primarily involves changes to error handling in various test cases across multiple files, along with an update to the package version in `package.json`. The error handling changes involve replacing the previous method of catching specific errors with a more general error catch block, which then checks if the caught error is an instance of the expected error.

Error handling changes:

* [`test/basic-api-errors-test.js`](diffhunk://#diff-177b6cf955a14b27d3804d1a6636f80cd218d138a96087d3350c0288bf175ce6L14-R20): Modified error handling in the tests `test transaction outside of session`, `test atomic outside of session`, `test getConnection after release`, and `test transaction after release` to use a general catch block and then check if the error is an instance of `db.NoSessionAvailable`. [[1]](diffhunk://#diff-177b6cf955a14b27d3804d1a6636f80cd218d138a96087d3350c0288bf175ce6L14-R20) [[2]](diffhunk://#diff-177b6cf955a14b27d3804d1a6636f80cd218d138a96087d3350c0288bf175ce6L24-R35) [[3]](diffhunk://#diff-177b6cf955a14b27d3804d1a6636f80cd218d138a96087d3350c0288bf175ce6L39-R55) [[4]](diffhunk://#diff-177b6cf955a14b27d3804d1a6636f80cd218d138a96087d3350c0288bf175ce6L70-R91)

* [`test/basic-atomic-error-test.js`](diffhunk://#diff-66385a0cec8099bc2eb47cd408949a6d68d2294f65aa4be4e4cebe19034bee47L67-R73): Modified error handling in the tests `test error in BEGIN` and `test error in COMMIT` to use a general catch block and then check if the error is an instance of `BeginError` or `CommitError` respectively. [[1]](diffhunk://#diff-66385a0cec8099bc2eb47cd408949a6d68d2294f65aa4be4e4cebe19034bee47L67-R73) [[2]](diffhunk://#diff-66385a0cec8099bc2eb47cd408949a6d68d2294f65aa4be4e4cebe19034bee47L103-R114)

* [`test/basic-session-error-test.js`](diffhunk://#diff-04a0ae70a38ddc9dfffcfaa311bdd509901fb9a94bc72a6a172016d8cec59fdaL28-R34): Modified error handling in the test `cannot connect` to use a general catch block and then check if the error is an instance of `TestError`.

* [`test/basic-transaction-error-test.js`](diffhunk://#diff-f033298d67bd755f50a74840255ad2665dd57660fe00dc178585dcc5bc14167dL67-R73): Modified error handling in the tests `test error in BEGIN` and `test error in COMMIT` to use a general catch block and then check if the error is an instance of `BeginError` or `CommitError` respectively. [[1]](diffhunk://#diff-f033298d67bd755f50a74840255ad2665dd57660fe00dc178585dcc5bc14167dL67-R73) [[2]](diffhunk://#diff-f033298d67bd755f50a74840255ad2665dd57660fe00dc178585dcc5bc14167dL103-R114)

Package version update:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the package version from `1.3.2` to `1.4.2`.