### PR TITLE
Potential fix for code scanning alert in `pg-db-session` Workflow

### DIFF
--- a/.github/workflows/publish_latest_version_to_gh.yml
+++ b/.github/workflows/publish_latest_version_to_gh.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches: [ master ]
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   compare_versions:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/npm/pg-db-session/security/code-scanning/1](https://github.com/npm/pg-db-session/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow to explicitly define the required permissions. Based on the workflow's functionality, it needs `contents: read` to access repository contents and `packages: write` to publish the npm package. These permissions are sufficient for the tasks performed in the workflow.

The `permissions` block will be added at the root level, applying to all jobs in the workflow. This ensures that no unnecessary permissions are granted to the `GITHUB_TOKEN`.

---

Ref: https://github.com/github/npm/issues/13757

_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
